### PR TITLE
Mark private fields as such and document mx_icon_theme_get_search_paths

### DIFF
--- a/mx/mx-droppable.h
+++ b/mx/mx-droppable.h
@@ -50,8 +50,10 @@ typedef struct _MxDroppableIface      MxDroppableIface;
 
 struct _MxDroppableIface
 {
+  /*< private >*/
   GTypeInterface g_iface;
 
+  /*< public >*/
   /* vfuncs, not signals */
   void     (* enable)      (MxDroppable *droppable);
   void     (* disable)     (MxDroppable *droppable);

--- a/mx/mx-icon-theme.c
+++ b/mx/mx-icon-theme.c
@@ -988,6 +988,14 @@ mx_icon_theme_has_icon (MxIconTheme *theme,
     return FALSE;
 }
 
+/**
+ * mx_icon_theme_get_search_paths:
+ * @theme: a #MxIconTheme
+ *
+ * Gets the directories the #MxIconTheme will search in to find icons.
+ *
+ * Return value: (element-type utf8) (transfer none): the search paths
+ */
 const GList *
 mx_icon_theme_get_search_paths (MxIconTheme *theme)
 {

--- a/mx/mx-scrollable.h
+++ b/mx/mx-scrollable.h
@@ -51,8 +51,10 @@ typedef struct _MxScrollableIface MxScrollableIface;
 
 struct _MxScrollableIface
 {
+  /*< private >*/
   GTypeInterface parent;
 
+  /*< public >*/
   void (* set_adjustments) (MxScrollable  *scrollable,
                             MxAdjustment  *hadjustment,
                             MxAdjustment  *vadjustment);

--- a/mx/mx-settings-provider.h
+++ b/mx/mx-settings-provider.h
@@ -47,8 +47,10 @@ typedef struct _MxSettingsProviderIface MxSettingsProviderIface;
 
 struct _MxSettingsProviderIface
 {
+  /*< private >*/
   GTypeInterface parent_iface;
 
+  /*< public >*/
   /* signals, not vfuncs */
   void (* setting_changed) (MxSettingsProvider *provider,
                             MxSettingsProperty  id);

--- a/mx/mx-stylable.h
+++ b/mx/mx-stylable.h
@@ -63,8 +63,10 @@ typedef enum
 
 struct _MxStylableIface
 {
+  /*< private >*/
   GTypeInterface g_iface;
 
+  /*< public >*/
   /* virtual functions */
   MxStyle *  (* get_style) (MxStylable *stylable);
   void       (* set_style) (MxStylable *stylable,


### PR DESCRIPTION
Lots of fields are not marked as private and mx_icon_theme_get_search_paths is not documented at all.

After this is pulled I'll switch the Vala bindings over to using the GIR.
