### PR TITLE
Update gjs-based JavaScript tests.

### DIFF
--- a/tests/javascript/buttons.js
+++ b/tests/javascript/buttons.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 Mx.Style.get_default ().load_from_file ("tests.css");
 

--- a/tests/javascript/slider.js
+++ b/tests/javascript/slider.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 Mx.Style.get_default ().load_from_file ("tests.css");
 

--- a/tests/javascript/test-actions.js
+++ b/tests/javascript/test-actions.js
@@ -54,7 +54,7 @@ function connect_cb (text)
   stage.show ();
 }
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let main_stage = Clutter.Stage.get_default ();
 main_stage.title = "Test Mx Actions";

--- a/tests/javascript/test-button-group.js
+++ b/tests/javascript/test-button-group.js
@@ -31,7 +31,7 @@ function add_button (name, box, group)
   return button;
 }
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let stage = Clutter.Stage.get_default ();
 stage.title = "Test Toolkit"

--- a/tests/javascript/test-combo-box.js
+++ b/tests/javascript/test-combo-box.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let stage = Clutter.Stage.get_default ();
 stage.title = "Test Combo Box";

--- a/tests/javascript/test-deformations.js
+++ b/tests/javascript/test-deformations.js
@@ -22,7 +22,7 @@ const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 const grey = new Clutter.Color(); grey.from_string ("grey");
 
-Clutter.init (0, null);
+Clutter.init (null);
 let app = new Mx.Application ({"application-name": "Test deformations"});
 
 let win = app.create_window ();

--- a/tests/javascript/test-icon-theme.js
+++ b/tests/javascript/test-icon-theme.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let stage = Clutter.Stage.get_default ();
 stage.title = "Test Icon Theme"

--- a/tests/javascript/test-notebook.js
+++ b/tests/javascript/test-notebook.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let stage = Clutter.Stage.get_default ();
 stage.title = "Test Notebook";

--- a/tests/javascript/test-path-bar.js
+++ b/tests/javascript/test-path-bar.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let stage = Clutter.Stage.get_default ();
 stage.title = "Test Path Bar"

--- a/tests/javascript/test-popup.js
+++ b/tests/javascript/test-popup.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let stage = Clutter.Stage.get_default ();
 stage.title = "Test Widget Popup"

--- a/tests/javascript/test-toggle-switch.js
+++ b/tests/javascript/test-toggle-switch.js
@@ -21,7 +21,7 @@
 const Clutter = imports.gi.Clutter;
 const Mx = imports.gi.Mx;
 
-Clutter.init (0, null);
+Clutter.init (null);
 
 let stage = Clutter.Stage.get_default ();
 stage.title = "Test Toggle";


### PR DESCRIPTION
gjs hasn't required length prefix arguments for a good while now.
