### PR TITLE
mx-create-image-cache: Using dynamic memory allocation for paths.

### DIFF
--- a/mx/mx-create-image-cache.c
+++ b/mx/mx-create-image-cache.c
@@ -417,7 +417,8 @@ static void write_cache_file(char *directory,
                              char *pngfile)
 {
   FILE *file;
-  char filename[PATH_MAX *2];
+  char *filename = NULL;
+  int len = 0;
   struct imgcache_element element;
   struct imgcache_element *elm;
   GList *item;
@@ -426,11 +427,14 @@ static void write_cache_file(char *directory,
 
   strcpy(&element.filename[0], pngfile);
 
+  len = strlen (directory) + 9;
+  filename = g_malloc (len + 1);
   sprintf(filename, "%s/mx.cache", directory);
 
   file = fopen(filename, "w");
   if (!file) {
       fprintf(stderr, "Cannot write cache file: %s\n", filename);
+      g_free (filename);
       return;
     }
   fwrite(&element, 1, sizeof(element), file);
@@ -442,6 +446,7 @@ static void write_cache_file(char *directory,
       elm->ptr = NULL;
       fwrite(elm, 1, sizeof(element), file);
     }
+  g_free (filename);
   fclose(file);
 
 }
@@ -449,7 +454,9 @@ static void write_cache_file(char *directory,
 int main(int    argc,
          char **argv)
 {
-  char image_file[PATH_MAX];
+  char *image_file = NULL;
+  int len = 0;
+
   if (argc <= 1) {
       printf("Usage:\n\t\tmakecache <directory>\n");
       return EXIT_FAILURE;
@@ -457,8 +464,11 @@ int main(int    argc,
   g_type_init();
   makecache(argv[1], 1);
   optimal_placement();
+  len = sizeof (guint) + 18;
+  image_file = g_malloc (len + 1);
   sprintf(image_file, "/var/cache/mx/%08x.png", g_str_hash(argv[1]));
   if (make_final_image(image_file))
     write_cache_file(argv[1], image_file);
+  g_free (image_file);
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Dynamic memory allocation is used to avoid the absence of a PATH_MAX
definition for GNU/Hurd.

Signed-off-by: Svante Signell svante.signell@telia.com
Signed-off-by: Ying-Chun Liu (PaulLiu) paulliu@debian.org
