### PR TITLE
work on MxMenu and MxComboBox

### DIFF
--- a/mx/mx-combo-box.c
+++ b/mx/mx-combo-box.c
@@ -454,6 +454,9 @@ mx_combo_box_allocate (ClutterActor          *actor,
   childbox.x2 = (box->x2 - box->x1);
   childbox.y1 = (box->y2 - box->y1);
 
+  childbox.y2 = childbox.y1 + nat_menu_h;
+
+
   stage = clutter_actor_get_stage (actor);
   if (stage != NULL)
     {
@@ -465,14 +468,39 @@ mx_combo_box_allocate (ClutterActor          *actor,
       clutter_actor_apply_transform_to_point (actor, &point, &point);
 
       /* If the menu would appear off the stage, flip it around. */
-      if ((point.x < 0) || (point.x >= stage_w) ||
-          (point.y < 0) || (point.y >= stage_h))
+      if ((point.y < 0) || (point.y >= stage_h))
+      {
+        childbox.y1 = -nat_menu_h;
+        point.y = -nat_menu_h;
+        clutter_actor_apply_transform_to_point (actor, &point, &point);
+        /* if the menu would still appear out of the stage, force
+         * it to appear on the top of the stage.
+         */
+        if(point.y<0)
         {
-          childbox.y1 = -nat_menu_h;
+          gfloat xactor, yactor;
+          clutter_actor_get_transformed_position(actor, &xactor, &yactor);
+          childbox.y1 = -yactor;
         }
+      }
+      
+      point.y = childbox.y1 + nat_menu_h;
+      clutter_actor_apply_transform_to_point (actor, &point, &point);
+      if( point.y >= stage_h)
+      {
+        gfloat xactor, yactor;
+        clutter_actor_get_transformed_position(actor, &xactor, &yactor);
+        /*
+         * clamp so that the menu doesn't appear out of the screen
+         */
+        clutter_actor_transform_stage_point (actor, xactor, stage_h,
+            NULL, &childbox.y2);
+      }
+      else
+      {
+        childbox.y2 = childbox.y1 + nat_menu_h;
+      }
     }
-
-  childbox.y2 = childbox.y1 + nat_menu_h;
   clutter_actor_allocate (menu, &childbox, flags);
 }
 

--- a/mx/mx-combo-box.c
+++ b/mx/mx-combo-box.c
@@ -419,7 +419,8 @@ mx_combo_box_allocate (ClutterActor          *actor,
       if (height >= nat_marker_h)
         {
           marker_h = nat_marker_h;
-          clutter_actor_get_preferred_width (priv->marker, -1, NULL, &marker_w);
+          clutter_actor_get_preferred_width (priv->marker, -1, NULL, 
+                                             &marker_w);
         }
       else
         {
@@ -456,7 +457,6 @@ mx_combo_box_allocate (ClutterActor          *actor,
 
   childbox.y2 = childbox.y1 + nat_menu_h;
 
-
   stage = clutter_actor_get_stage (actor);
   if (stage != NULL)
     {
@@ -469,37 +469,38 @@ mx_combo_box_allocate (ClutterActor          *actor,
 
       /* If the menu would appear off the stage, flip it around. */
       if ((point.y < 0) || (point.y >= stage_h))
-      {
-        childbox.y1 = -nat_menu_h;
-        point.y = -nat_menu_h;
-        clutter_actor_apply_transform_to_point (actor, &point, &point);
-        /* if the menu would still appear out of the stage, force
-         * it to appear on the top of the stage.
-         */
-        if(point.y<0)
         {
-          gfloat xactor, yactor;
-          clutter_actor_get_transformed_position(actor, &xactor, &yactor);
-          childbox.y1 = -yactor;
+          childbox.y1 = -nat_menu_h;
+          point.y = -nat_menu_h;
+          clutter_actor_apply_transform_to_point (actor, &point, &point);
+          /* if the menu would still appear out of the stage, force
+           * it to appear on the top of the stage.
+           */
+          if (point.y < 0)
+            {
+              gfloat xactor, yactor;
+              clutter_actor_get_transformed_position (actor, &xactor, 
+                                                      &yactor);
+              childbox.y1 = -yactor;
+            }
         }
-      }
       
       point.y = childbox.y1 + nat_menu_h;
       clutter_actor_apply_transform_to_point (actor, &point, &point);
-      if( point.y >= stage_h)
-      {
-        gfloat xactor, yactor;
-        clutter_actor_get_transformed_position(actor, &xactor, &yactor);
-        /*
-         * clamp so that the menu doesn't appear out of the screen
-         */
-        clutter_actor_transform_stage_point (actor, xactor, stage_h,
-            NULL, &childbox.y2);
-      }
+      if (point.y >= stage_h)
+        {
+          gfloat xactor, yactor;
+          clutter_actor_get_transformed_position (actor, &xactor, &yactor);
+          /*
+           * clamp so that the menu doesn't appear out of the screen
+           */
+          clutter_actor_transform_stage_point (actor, xactor, stage_h,
+                                               NULL, &childbox.y2);
+        }
       else
-      {
-        childbox.y2 = childbox.y1 + nat_menu_h;
-      }
+        {
+          childbox.y2 = childbox.y1 + nat_menu_h;
+        }
     }
   clutter_actor_allocate (menu, &childbox, flags);
 }

--- a/mx/mx-menu.c
+++ b/mx/mx-menu.c
@@ -57,6 +57,15 @@ struct _MxMenuPrivate
   gulong captured_event_handler;
 
   gulong internal_focus_push : 1;
+
+  gulong scrolling_mode : 1;
+  ClutterActorBox allocation;
+  gint id_offset;
+  gint last_shown_id;
+  ClutterActor *up_button;
+  ClutterActor *down_button;
+  gulong up_source;
+  gulong down_source;
 };
 
 enum
@@ -103,9 +112,21 @@ mx_menu_move_focus (MxFocusable      *focusable,
     {
     case MX_FOCUS_DIRECTION_UP:
       if (i == 0)
+      {
         i = priv->children->len - 1;
+        gint nb_elts = priv->last_shown_id - priv->id_offset;
+        priv->id_offset = i - nb_elts;
+        clutter_actor_queue_redraw(CLUTTER_ACTOR(focusable));
+      }
       else
+      {
         i--;
+        if(i < priv->id_offset)
+        {
+          priv->id_offset--;
+          clutter_actor_queue_redraw(CLUTTER_ACTOR(focusable));
+        }
+      }
 
       while (i >= 0)
         {
@@ -129,9 +150,20 @@ mx_menu_move_focus (MxFocusable      *focusable,
 
     case MX_FOCUS_DIRECTION_DOWN:
       if (i == priv->children->len - 1)
+      {
+        priv->id_offset = 0;
         i = 0;
+        clutter_actor_queue_redraw(CLUTTER_ACTOR(focusable));
+      }
       else
+      {
         i++;
+        if(i > priv->last_shown_id)
+        {
+          priv->id_offset++;
+          clutter_actor_queue_redraw(CLUTTER_ACTOR(focusable));
+        }
+      }
 
       while (i < priv->children->len)
         {
@@ -340,12 +372,69 @@ mx_menu_allocate (ClutterActor           *actor,
   ClutterActorBox child_box;
   MxMenuPrivate *priv = MX_MENU (actor)->priv;
 
+  gfloat available_h = box->y2-box->y1;
+
+  /* 
+   * if the allocation has changed, we have to check if we have
+   * enough place to draw the whole menu.
+   * At this place, even if we didn't chain up with parent, (and
+   * the allocation stored in the ClutterActor structure has not yet
+   * changed) we cannot call clutter_actor_get_allocation_box
+   * because it would call us... Beware of the infinite call
+   * loop... That's why we store the allocation box.
+   */
+  if(priv->allocation.x1 != box->x1 || priv->allocation.x2 != box->x2 ||
+      priv->allocation.y1 != box->y1 || priv->allocation.y2 != box->y2 )
+  {
+    /* 
+     * first of all, we have to check if the allocated height is our
+     * natural height...
+     */
+    gfloat menu_nat_h;
+    mx_menu_get_preferred_height (actor, box->x2-box->x1, NULL, &menu_nat_h);
+    if(available_h < menu_nat_h)
+    {
+      /*
+       * ...if not, we have to draw 2 buttons in order to let the
+       * user be able to navigate in the whole menu.
+       */
+      priv->scrolling_mode = TRUE;
+    }
+    else
+    {
+      priv->scrolling_mode = FALSE;
+    }
+  }
+  priv->allocation = *box;
+
+
   /* Allocate children */
   mx_widget_get_padding (MX_WIDGET (actor), &padding);
   child_box.x1 = padding.left;
   child_box.y1 = padding.top;
   child_box.x2 = box->x2 - box->x1 - padding.right;
-  for (i = 0; i < priv->children->len; i++)
+
+  gfloat down_but_height;
+  clutter_actor_get_preferred_height (priv->down_button,
+        child_box.x2 - child_box.x1,
+        NULL,
+        &down_but_height);
+
+  if(priv->scrolling_mode)
+  {
+    clutter_actor_get_preferred_height (priv->up_button,
+        child_box.x2 - child_box.x1,
+        NULL,
+        &child_box.y2);
+    child_box.y2 += child_box.y1;
+    clutter_actor_allocate (priv->up_button, &child_box, flags);
+    child_box.y1 = child_box.y2 + 1;
+
+    available_h -= down_but_height;
+  }
+
+  
+  for (i = priv->id_offset; i < priv->children->len; i++)
     {
       gfloat natural_height;
 
@@ -357,12 +446,26 @@ mx_menu_allocate (ClutterActor           *actor,
                                           NULL,
                                           &natural_height);
       child_box.y2 = child_box.y1 + natural_height;
+      if(child_box.y2 >= available_h)
+      {
+        priv->last_shown_id = i-1;
+        break;
+      }
 
       clutter_actor_allocate (CLUTTER_ACTOR (child->box), &child_box, flags);
 
       child_box.y1 = child_box.y2 + 1;
     }
+    if(priv->children->len == i)
+    {
+        priv->last_shown_id = i-1;
+    }
 
+    if(priv->scrolling_mode)
+    {
+      child_box.y2 = child_box.y1 + down_but_height;
+      clutter_actor_allocate (priv->down_button, &child_box, flags);
+    }
   /* Chain up and allocate background */
   CLUTTER_ACTOR_CLASS (mx_menu_parent_class)->allocate (actor, box, flags);
 }
@@ -377,12 +480,18 @@ mx_menu_floating_paint (ClutterActor *menu)
   MX_FLOATING_WIDGET_CLASS (mx_menu_parent_class)->floating_paint (menu);
 
   /* Paint children */
-  for (i = 0; i < priv->children->len; i++)
+  for (i = priv->id_offset; i <= priv->last_shown_id; i++)
     {
       MxMenuChild *child = &g_array_index (priv->children, MxMenuChild,
                                             i);
       clutter_actor_paint (CLUTTER_ACTOR (child->box));
     }
+  
+  if(priv->scrolling_mode)
+  {
+    clutter_actor_paint(priv->up_button);
+    clutter_actor_paint(priv->down_button);
+  }
 }
 
 static void
@@ -397,7 +506,7 @@ mx_menu_floating_pick (ClutterActor       *menu,
   MX_FLOATING_WIDGET_CLASS (mx_menu_parent_class)->floating_pick (menu, color);
 
   /* pick children */
-  for (i = 0; i < priv->children->len; i++)
+  for (i = priv->id_offset; i <= priv->last_shown_id; i++)
     {
       MxMenuChild *child = &g_array_index (priv->children, MxMenuChild, i);
 
@@ -406,6 +515,11 @@ mx_menu_floating_pick (ClutterActor       *menu,
           clutter_actor_paint (CLUTTER_ACTOR (child->box));
         }
     }
+  if(priv->scrolling_mode)
+  {
+    clutter_actor_paint(priv->up_button);
+    clutter_actor_paint(priv->down_button);
+  }
 }
 
 static void
@@ -423,6 +537,8 @@ mx_menu_map (ClutterActor *actor)
 
   CLUTTER_ACTOR_CLASS (mx_menu_parent_class)->map (actor);
 
+  clutter_actor_map (priv->up_button);
+  clutter_actor_map (priv->down_button);
   for (i = 0; i < priv->children->len; i++)
     {
       MxMenuChild *child = &g_array_index (priv->children, MxMenuChild,
@@ -450,6 +566,8 @@ mx_menu_unmap (ClutterActor *actor)
 
   CLUTTER_ACTOR_CLASS (mx_menu_parent_class)->unmap (actor);
 
+  clutter_actor_unmap (priv->up_button);
+  clutter_actor_unmap (priv->down_button);
   for (i = 0; i < priv->children->len; i++)
     {
       MxMenuChild *child = &g_array_index (priv->children, MxMenuChild,
@@ -528,6 +646,8 @@ mx_menu_captured_event_handler (ClutterActor *actor,
       if (source == (ClutterActor*) child->box)
         return FALSE;
     }
+  if(source == priv->up_button || source == priv->down_button)
+    return FALSE;
 
   /* hide the menu if the user clicks outside the menu */
   if (event->type == CLUTTER_BUTTON_PRESS)
@@ -638,6 +758,73 @@ mx_menu_class_init (MxMenuClass *klass)
                   G_TYPE_NONE, 1, MX_TYPE_ACTION);
 }
 
+static gboolean
+_up_callback(MxMenu *self)
+{
+  MxMenuPrivate *priv = self->priv;
+  if (0 < priv->id_offset)
+  {
+    priv->id_offset--;
+    clutter_actor_queue_relayout(CLUTTER_ACTOR(self));
+  }
+  return TRUE;
+}
+
+static gboolean
+mx_menu_up_enter(ClutterActor         *actor, 
+                 ClutterCrossingEvent *event, 
+                 MxMenu               *self)
+{
+  MxMenuPrivate *priv = self->priv;
+  priv->up_source = g_timeout_add(250, (GSourceFunc)_up_callback, self);
+  return FALSE;
+}
+
+static gboolean
+mx_menu_up_leave(ClutterActor         *actor, 
+                 ClutterCrossingEvent *event, 
+                 MxMenu               *self)
+{
+  MxMenuPrivate *priv = self->priv;
+  g_source_remove(priv->up_source);
+  return FALSE;
+}
+
+static gboolean
+_down_callback(MxMenu *self)
+{
+  MxMenuPrivate *priv = self->priv;
+  gint last_id_offset = (priv->children->len - 1) - 
+    (priv->last_shown_id - priv->id_offset);
+
+  if(last_id_offset > priv->id_offset)
+  {
+    priv->id_offset++;
+    clutter_actor_queue_relayout(CLUTTER_ACTOR(self));
+  }
+  return TRUE;
+}
+
+static gboolean
+mx_menu_down_enter(ClutterActor         *actor,
+                   ClutterCrossingEvent *event, 
+                   MxMenu               *self)
+{
+  MxMenuPrivate *priv = self->priv;
+  priv->down_source = g_timeout_add(250, (GSourceFunc)_down_callback, self);
+  return FALSE;
+}
+
+static gboolean
+mx_menu_down_leave(ClutterActor         *actor, 
+                   ClutterCrossingEvent *event,
+                   MxMenu               *self)
+{
+  MxMenuPrivate *priv = self->priv;
+  g_source_remove(priv->down_source);
+  return FALSE;
+}
+
 static void
 mx_menu_init (MxMenu *self)
 {
@@ -651,6 +838,23 @@ mx_menu_init (MxMenu *self)
 
   g_signal_connect (self, "style-changed", G_CALLBACK (mx_menu_style_changed),
                     NULL);
+  priv->id_offset = 0;
+  priv->last_shown_id = 0;
+  
+  priv->up_button = mx_button_new_with_label("/\\");
+  clutter_actor_set_parent (CLUTTER_ACTOR (priv->up_button),
+                            CLUTTER_ACTOR (self));
+  g_signal_connect(priv->up_button, "enter-event", 
+      G_CALLBACK(mx_menu_up_enter), self);
+  g_signal_connect(priv->up_button, "leave-event", 
+      G_CALLBACK(mx_menu_up_leave), self);
+  priv->down_button = mx_button_new_with_label("\\/");
+  clutter_actor_set_parent (CLUTTER_ACTOR (priv->down_button),
+                            CLUTTER_ACTOR (self));
+  g_signal_connect(priv->down_button, "enter-event", 
+      G_CALLBACK(mx_menu_down_enter), self);
+  g_signal_connect(priv->down_button, "leave-event", 
+      G_CALLBACK(mx_menu_down_leave), self);
 }
 
 /**


### PR DESCRIPTION
The idea is that if the MxComboBox has too many children, when the combo-box is opened, some elements are drawn out of the stage.

This work makes the MxComboBox allocate either the natural space of its MxMenu, or the maximum for the stage. If the allocated size for the MxMenu is smaller than its natural size, the user is able to scroll through all the elements with the keyboard or the inserted up and down buttons (like gnome menus).
