### PR TITLE
Fix underlinking detected by gold linker #49

### DIFF
--- a/mx/Makefile.am
+++ b/mx/Makefile.am
@@ -262,7 +262,7 @@ libmx_@MX_API_VERSION@_la_SOURCES =	\
 	$(top_srcdir)/mx/mx.h 		\
 	$(NULL)
 
-libmx_@MX_API_VERSION@_la_LIBADD = $(MX_LIBS)
+libmx_@MX_API_VERSION@_la_LIBADD = $(MX_LIBS) -lm
 
 if HAVE_INTROSPECTION
 -include $(INTROSPECTION_MAKEFILE)


### PR DESCRIPTION
Due to the extended underlinking detection of gold,
it is necessary to add libm to the linked libs.

https://github.com/clutter-project/mx/issues/49
