### PR TITLE
Add missing gl.h includes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,19 @@
+1.4.2
+=====
+
+Changes since 1.4.1
+
+ * create-image-cache: use dynamic memory allocation for paths
+ * entry: conditionally disable code that depends on X11
+ * kinetic-scroll-view: correctly clamp to the center
+ * offscreen: only restore the cogl state if it had been modified
+
+Fixed bugs (from bugzilla.clutter-project.org):
+
+  #2614 - Document the need for ClutterGesture for MxScrollView gestures
+  #2686 - Crash in xsettings_notify_func() due to NULL setting
+
+
 1.4.1
 =====
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+1.4.3
+=====
+
+Changes since 1.4.2
+
+
+ * slider: allow the handle button press and release events to propagate
+ * widget: ensure the "disabled" pseudo class is set when needed
+ * toggle: bind the "disabled" property of the handle and the toggle
+ * entry: use an empty string if the "text" property is set to NULL
+ * tooltip: update position when changing the text
+ * button/widget: don't rely on private variables to track hover state
+ * toggle: change timeline direction even if playing already
+
+
 1.4.2
 =====
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+1.4.7
+=====
+
+Changes since 1.4.6
+
+Fixed Bugs (from bugzilla.clutter-project.org):
+
+  #2688 - image: add some annotations for mx_image_set_from_buffer/data
+  #2687 - widget: Handle NULL ClutterEventCrossing->related actor in
+          mx_widget_leave
+  #2690 - MxScrollView: Fixed to clip events for clipped child area in
+          ClutterActor->pick()
+
+
 1.4.6
 =====
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+1.4.4
+=====
+
+Changes since 1.4.3
+
+ * Improved compatibility with Clutter 1.9
+ * button: avoid setting the ClutterText "text" property to NULL
+
+
 1.4.3
 =====
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+1.4.1
+=====
+
+Changes since 1.4.0
+
+  * Prevent warnings from MxImage by not closing the pixbuf loader before
+    calling g_object_unref.
+  * Honor the disabled property in MxToggle.
+  * Prevent warnings when using MxAction with glib 2.28.
+
+
 1.4.0
 =====
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+1.4.6
+=====
+
+Changes since 1.4.5
+
+ * Fix an issue with picking in MxStack
+ * Fix linking when using ld.gold linker
+
+
 1.4.5
 =====
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,21 @@
+1.4.5
+=====
+
+Changes since 1.4.4
+
+ * dialog: ensure that the initial size of the dialog is correct
+ * dialog: disable the blurred background when using Clutter ≥ 1.10
+ * css: pseudo-class should be identified by ':' in debug output
+ * combo-box: don't use NULL when setting the ClutterText "text" property
+ * test-containers: create a grid of actors in a group for viewport tests
+ * viewport: implement apply_transform and get_paint_volume
+ * scroll-view: clip around the child instead of setting clip-to-allocation
+ * table: fix sorting depth
+ * entry: Don't emit the notify text signal on switching between the hint text
+ * application: ensure the singleton variable is properly assigned
+ * adjustment: emit the "changed" signal if the value property changes
+
+
 1.4.4
 =====
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([mx_major], [1])
 m4_define([mx_minor], [4])
-m4_define([mx_micro], [5])
+m4_define([mx_micro], [6])
 
 m4_define([mx_version], [mx_major.mx_minor.mx_micro])
 m4_define([mx_api_version], [mx_major.0])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([mx_major], [1])
 m4_define([mx_minor], [4])
-m4_define([mx_micro], [3])
+m4_define([mx_micro], [4])
 
 m4_define([mx_version], [mx_major.mx_minor.mx_micro])
 m4_define([mx_api_version], [mx_major.0])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([mx_major], [1])
 m4_define([mx_minor], [4])
-m4_define([mx_micro], [6])
+m4_define([mx_micro], [7])
 
 m4_define([mx_version], [mx_major.mx_minor.mx_micro])
 m4_define([mx_api_version], [mx_major.0])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([mx_major], [1])
 m4_define([mx_minor], [4])
-m4_define([mx_micro], [2])
+m4_define([mx_micro], [3])
 
 m4_define([mx_version], [mx_major.mx_minor.mx_micro])
 m4_define([mx_api_version], [mx_major.0])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([mx_major], [1])
 m4_define([mx_minor], [4])
-m4_define([mx_micro], [4])
+m4_define([mx_micro], [5])
 
 m4_define([mx_version], [mx_major.mx_minor.mx_micro])
 m4_define([mx_api_version], [mx_major.0])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([mx_major], [1])
 m4_define([mx_minor], [4])
-m4_define([mx_micro], [1])
+m4_define([mx_micro], [2])
 
 m4_define([mx_version], [mx_major.mx_minor.mx_micro])
 m4_define([mx_api_version], [mx_major.0])

--- a/mx/Makefile.am
+++ b/mx/Makefile.am
@@ -268,7 +268,7 @@ libmx_@MX_API_VERSION@_la_SOURCES =	\
 	$(top_srcdir)/mx/mx.h 		\
 	$(NULL)
 
-libmx_@MX_API_VERSION@_la_LIBADD = $(MX_LIBS)
+libmx_@MX_API_VERSION@_la_LIBADD = $(MX_LIBS) -lm
 
 if HAVE_INTROSPECTION
 -include $(INTROSPECTION_MAKEFILE)

--- a/mx/mx-adjustment.c
+++ b/mx/mx-adjustment.c
@@ -117,6 +117,8 @@ static void mx_adjustment_clamp_page (MxAdjustment *adjustment,
                                       gdouble       lower,
                                       gdouble       upper);
 
+static void mx_adjustment_emit_changed (MxAdjustment *adjustment);
+
 static void
 mx_adjustment_constructed (GObject *object)
 {
@@ -588,6 +590,7 @@ mx_adjustment_set_value (MxAdjustment *adjustment,
       priv->value = value;
 
       g_object_notify (G_OBJECT (adjustment), "value");
+      mx_adjustment_emit_changed (adjustment);
     }
 }
 

--- a/mx/mx-application.c
+++ b/mx/mx-application.c
@@ -109,7 +109,7 @@ mx_application_constructor (GType                  type,
         G_OBJECT_CLASS (mx_application_parent_class)->constructor (type,
                                                                    n_construct_params,
                                                                    construct_params);
-      app_singleton = MX_APPLICATION (app_singleton);
+      app_singleton = MX_APPLICATION (object);
     }
   else
     object = g_object_ref (G_OBJECT (app_singleton));

--- a/mx/mx-button.c
+++ b/mx/mx-button.c
@@ -1140,6 +1140,7 @@ mx_button_set_action (MxButton *button,
                       MxAction *action)
 {
   MxButtonPrivate *priv;
+  const gchar *display_name;
 
   g_return_if_fail (MX_IS_BUTTON (button));
   g_return_if_fail (MX_IS_ACTION (action));
@@ -1157,9 +1158,11 @@ mx_button_set_action (MxButton *button,
 
   priv->action = g_object_ref_sink (action);
 
+  display_name = mx_action_get_display_name (action);
+
   mx_icon_set_icon_name (MX_ICON (priv->icon), mx_action_get_icon (action));
   clutter_text_set_text (CLUTTER_TEXT (priv->label),
-                                       mx_action_get_display_name (action));
+                         (display_name) ? display_name : "");
 
   /* bind action properties to button properties */
   priv->action_label_binding = g_object_bind_property (action, "display-name",

--- a/mx/mx-button.c
+++ b/mx/mx-button.c
@@ -90,7 +90,6 @@ struct _MxButtonPrivate
   guint8            old_opacity;
 
   guint             is_pressed : 1;
-  guint             is_hover : 1;
   guint             is_toggle : 1;
   guint             is_toggled : 1;
 
@@ -395,7 +394,6 @@ static gboolean
 mx_button_enter (ClutterActor         *actor,
                  ClutterCrossingEvent *event)
 {
-  MxButton *button = MX_BUTTON (actor);
   MxWidget *widget = MX_WIDGET (actor);
 
   if (event->source != actor)
@@ -407,8 +405,6 @@ mx_button_enter (ClutterActor         *actor,
 
 
   mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "hover");
-
-  button->priv->is_hover = 1;
 
   return FALSE;
 }
@@ -430,9 +426,6 @@ mx_button_leave (ClutterActor         *actor,
   /* check if the widget is disabled */
   if (mx_widget_get_disabled (MX_WIDGET (actor)))
     return FALSE;
-
-
-  button->priv->is_hover = 0;
 
   if (button->priv->is_pressed)
     {

--- a/mx/mx-combo-box.c
+++ b/mx/mx-combo-box.c
@@ -1017,7 +1017,7 @@ mx_combo_box_set_index (MxComboBox *box,
   if (!item)
     {
       box->priv->index = -1;
-      clutter_text_set_text ((ClutterText*) box->priv->label, NULL);
+      clutter_text_set_text ((ClutterText*) box->priv->label, "");
       return;
     }
 

--- a/mx/mx-combo-box.c
+++ b/mx/mx-combo-box.c
@@ -217,7 +217,8 @@ mx_combo_box_unmap (ClutterActor *actor)
 
   CLUTTER_ACTOR_CLASS (mx_combo_box_parent_class)->unmap (actor);
 
-  clutter_actor_unmap (priv->label);
+  if (priv->label)
+    clutter_actor_unmap (priv->label);
 
   if (priv->icon)
     clutter_actor_unmap (priv->icon);

--- a/mx/mx-create-image-cache.c
+++ b/mx/mx-create-image-cache.c
@@ -32,6 +32,11 @@
 #include <glib.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 
+
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+#endif
+
 struct imgcache_element {
   char  filename[256];
   int   width, height;

--- a/mx/mx-create-image-cache.c
+++ b/mx/mx-create-image-cache.c
@@ -422,7 +422,7 @@ static void write_cache_file(char *directory,
                              char *pngfile)
 {
   FILE *file;
-  char filename[PATH_MAX *2];
+  char *filename = NULL;
   struct imgcache_element element;
   struct imgcache_element *elm;
   GList *item;
@@ -431,11 +431,12 @@ static void write_cache_file(char *directory,
 
   strcpy(&element.filename[0], pngfile);
 
-  sprintf(filename, "%s/mx.cache", directory);
+  filename = g_strdup_printf("%s/mx.cache", directory);
 
   file = fopen(filename, "w");
   if (!file) {
       fprintf(stderr, "Cannot write cache file: %s\n", filename);
+      g_free (filename);
       return;
     }
   fwrite(&element, 1, sizeof(element), file);
@@ -447,6 +448,7 @@ static void write_cache_file(char *directory,
       elm->ptr = NULL;
       fwrite(elm, 1, sizeof(element), file);
     }
+  g_free (filename);
   fclose(file);
 
 }
@@ -454,7 +456,8 @@ static void write_cache_file(char *directory,
 int main(int    argc,
          char **argv)
 {
-  char image_file[PATH_MAX];
+  char *image_file = NULL;
+
   if (argc <= 1) {
       printf("Usage:\n\t\tmakecache <directory>\n");
       return EXIT_FAILURE;
@@ -462,8 +465,9 @@ int main(int    argc,
   g_type_init();
   makecache(argv[1], 1);
   optimal_placement();
-  sprintf(image_file, "/var/cache/mx/%08x.png", g_str_hash(argv[1]));
+  image_file = g_strdup_printf("/var/cache/mx/%08x.png", g_str_hash(argv[1]));
   if (make_final_image(image_file))
     write_cache_file(argv[1], image_file);
+  g_free (image_file);
   return EXIT_SUCCESS;
 }

--- a/mx/mx-css.c
+++ b/mx/mx-css.c
@@ -321,7 +321,7 @@ selector_to_string (MxSelector *selector)
                             (selector->class) ? selector->class : "",
                             (selector->id) ? "#" : "",
                             (selector->id) ? selector->id : "",
-                            (selector->pseudo_class) ? "#" : "",
+                            (selector->pseudo_class) ? ":" : "",
                             (selector->pseudo_class)
                             ? selector->pseudo_class : "");
 

--- a/mx/mx-deform-texture.c
+++ b/mx/mx-deform-texture.c
@@ -29,6 +29,8 @@
  * deformation effects with a texture.
  */
 
+#include <GL/gl.h>
+
 #include "mx-deform-texture.h"
 #include "mx-offscreen.h"
 #include "mx-private.h"

--- a/mx/mx-dialog.c
+++ b/mx/mx-dialog.c
@@ -772,8 +772,11 @@ mx_dialog_unmap (ClutterActor *actor)
                                               actor);
     }
 
-  clutter_actor_unmap (priv->button_box);
-  clutter_actor_unmap (priv->background);
+  if (priv->button_box)
+    clutter_actor_unmap (priv->button_box);
+
+  if (priv->background)
+    clutter_actor_unmap (priv->background);
 
   if (priv->blur)
     clutter_actor_unmap (priv->blur);

--- a/mx/mx-dialog.c
+++ b/mx/mx-dialog.c
@@ -983,7 +983,8 @@ mx_dialog_init (MxDialog *self)
 
   /* Compile the shader when creating the instance so it's ready when we need
    * it */
-  if (clutter_feature_available (CLUTTER_FEATURE_SHADERS_GLSL) &&
+  if (!CLUTTER_CHECK_VERSION (1, 10, 0) &&
+      clutter_feature_available (CLUTTER_FEATURE_SHADERS_GLSL) &&
       clutter_feature_available (CLUTTER_FEATURE_OFFSCREEN))
     {
       GError *error = NULL;

--- a/mx/mx-dialog.c
+++ b/mx/mx-dialog.c
@@ -294,7 +294,8 @@ mx_dialog_allocate_cb (ClutterActor           *parent,
   child_box.x2 = box->x2 - box->x1;
   child_box.y2 = box->y2 - box->y1;
 
-  clutter_actor_allocate (CLUTTER_ACTOR (self), &child_box, flags);
+  clutter_actor_set_width (self, box->x2 - box->x1);
+  clutter_actor_set_height (self, box->y2 - box->y1);
 }
 
 static void
@@ -1064,6 +1065,7 @@ mx_dialog_show (ClutterActor *self)
   if (!priv->visible)
     {
       ClutterActor *parent = clutter_actor_get_parent (self);
+      ClutterActorBox box;
 
       if (!parent)
         return;
@@ -1126,6 +1128,11 @@ mx_dialog_show (ClutterActor *self)
       clutter_timeline_start (priv->timeline);
 
       mx_dialog_steal_focus (dialog);
+
+
+      /* ensure the initial size is correct */
+      clutter_actor_get_allocation_box (parent, &box);
+      mx_dialog_allocate_cb (parent, &box, CLUTTER_ALLOCATION_NONE, dialog);
     }
 }
 

--- a/mx/mx-entry.c
+++ b/mx/mx-entry.c
@@ -1450,12 +1450,18 @@ mx_entry_get_text (MxEntry *entry)
  */
 void
 mx_entry_set_text (MxEntry     *entry,
-                   const gchar *text)
+                   const gchar *entry_text)
 {
   MxEntryPrivate *priv;
   gunichar password_char;
+  const gchar *text;
 
   g_return_if_fail (MX_IS_ENTRY (entry));
+
+  if (entry_text)
+    text = entry_text;
+  else
+    text = "";
 
   priv = entry->priv;
 

--- a/mx/mx-entry.c
+++ b/mx/mx-entry.c
@@ -826,7 +826,8 @@ mx_entry_unmap (ClutterActor *actor)
 
   CLUTTER_ACTOR_CLASS (mx_entry_parent_class)->unmap (actor);
 
-  clutter_actor_unmap (priv->entry);
+  if (priv->entry)
+    clutter_actor_unmap (priv->entry);
 
   if (priv->primary_icon)
     clutter_actor_unmap (priv->primary_icon);

--- a/mx/mx-entry.c
+++ b/mx/mx-entry.c
@@ -651,6 +651,8 @@ mx_entry_allocate (ClutterActor          *actor,
 
 }
 
+static void clutter_text_changed_cb (ClutterText *text, MxEntry     *entry);
+
 static void
 clutter_text_focus_in_cb (ClutterText  *text,
                           ClutterActor *actor)
@@ -662,7 +664,19 @@ clutter_text_focus_in_cb (ClutterText  *text,
     {
       priv->hint_visible = FALSE;
 
+      /* We don't want to emit the notify text change when we're swapping
+       * between the hint text and blank for entry.
+       */
+      g_signal_handlers_block_by_func (priv->entry,
+                                       clutter_text_changed_cb,
+                                       MX_ENTRY (actor));
+
       clutter_text_set_text (text, "");
+
+      g_signal_handlers_unblock_by_func (priv->entry,
+                                         clutter_text_changed_cb,
+                                         MX_ENTRY (actor));
+
 
       if (priv->password_char != 0)
         {
@@ -687,7 +701,19 @@ clutter_text_focus_out_cb (ClutterText  *text,
     {
       priv->hint_visible = TRUE;
 
+      /* We don't want to emit the notify text change when we're swapping
+       * between the hint text and blank for entry.
+       */
+      g_signal_handlers_block_by_func (priv->entry,
+                                       clutter_text_changed_cb,
+                                       MX_ENTRY (actor));
+
       clutter_text_set_text (text, priv->hint);
+
+      g_signal_handlers_unblock_by_func (priv->entry,
+                                         clutter_text_changed_cb,
+                                         MX_ENTRY (actor));
+
       mx_stylable_set_style_pseudo_class (MX_STYLABLE (actor), "indeterminate");
 
       if (clutter_text_get_password_char (text) != 0)

--- a/mx/mx-entry.c
+++ b/mx/mx-entry.c
@@ -1060,6 +1060,7 @@ mx_entry_key_focus_in (ClutterActor *actor)
   clutter_actor_grab_key_focus (priv->entry);
 }
 
+#ifdef HAVE_X11
 static void
 mx_entry_set_cursor (MxEntry  *entry,
                      gboolean  use_ibeam)
@@ -1081,6 +1082,7 @@ mx_entry_set_cursor (MxEntry  *entry,
   else
     XUndefineCursor (dpy, wid);
 }
+#endif
 
 static gboolean
 mx_entry_swallow_crossing_event (ClutterActor         *actor,
@@ -1311,10 +1313,12 @@ entry_event (ClutterActor *actor,
              ClutterEvent *event,
              MxEntry      *entry)
 {
+#ifdef HAVE_X11
   /* ensure the cursor is in the correct state when the mouse button is
    * released */
   if (event->type == CLUTTER_BUTTON_RELEASE)
     mx_entry_set_cursor (entry, entry->priv->pointer_in_entry);
+#endif
 
   /* don't track enter and leave events for actors other than the entry */
   if (event->any.source != actor)

--- a/mx/mx-image.c
+++ b/mx/mx-image.c
@@ -1146,7 +1146,7 @@ mx_image_set_from_data_internal (MxImage          *image,
 /**
  * mx_image_set_from_data:
  * @image: An #MxImage
- * @data: Image data
+ * @data: (array): Image data
  * @pixel_format: The #CoglPixelFormat of the buffer
  * @width: Width in pixels of image data.
  * @height: Height in pixels of image data
@@ -1872,9 +1872,10 @@ mx_image_set_from_cogl_texture (MxImage    *image,
 /**
  * mx_image_set_from_buffer:
  * @image: An #MxImage
- * @buffer: A buffer pointing to encoded image data
+ * @buffer: (array length=buffer_size) (transfer full): A buffer
+ *   pointing to encoded image data
  * @buffer_size: The size of @buffer, in bytes
- * @buffer_free_func: A function to free @buffer, or %NULL
+ * @buffer_free_func: (allow-none): A function to free @buffer, or %NULL
  * @error: Return location for a #GError, or #NULL
  *
  * Set the image data from unencoded image data, stored in memory. In case of
@@ -1900,9 +1901,10 @@ mx_image_set_from_buffer (MxImage         *image,
 /**
  * mx_image_set_from_buffer_at_size:
  * @image: An #MxImage
- * @buffer: A buffer pointing to encoded image data
+ * @buffer: (array length=buffer_size) (transfer full): A buffer
+ *   pointing to encoded image data
  * @buffer_size: The size of @buffer, in bytes
- * @buffer_free_func: A function to free @buffer, or %NULL
+ * @buffer_free_func: (allow-none): A function to free @buffer, or %NULL
  * @width: Width to scale the image to, or -1
  * @height: Height to scale the image to, or -1
  * @error: Return location for a #GError, or #NULL

--- a/mx/mx-image.c
+++ b/mx/mx-image.c
@@ -1448,6 +1448,7 @@ mx_image_pixbuf_new (const gchar  *filename,
         {
           if (error)
             g_propagate_error (error, err);
+          gdk_pixbuf_loader_close (loader, NULL);
           g_object_unref (loader);
           return NULL;
         }
@@ -1457,6 +1458,7 @@ mx_image_pixbuf_new (const gchar  *filename,
 
   if (!buffer)
     {
+      gdk_pixbuf_loader_close (loader, NULL);
       g_object_unref (loader);
       return NULL;
     }
@@ -1465,6 +1467,7 @@ mx_image_pixbuf_new (const gchar  *filename,
     {
       if (error)
         g_propagate_error (error, err);
+      gdk_pixbuf_loader_close (loader, NULL);
       g_object_unref (loader);
       return NULL;
     }

--- a/mx/mx-kinetic-scroll-view.c
+++ b/mx/mx-kinetic-scroll-view.c
@@ -689,11 +689,20 @@ clamp_adjustment (MxKineticScrollView *scroll,
   mx_adjustment_get_values (adj, &value, &lower, &upper,
                             &step_increment, NULL, &page_size);
 
-  if (priv->clamp_to_center)
-    lower += ((int) page_size % (int) step_increment) * 2;
-
   d = (rint ((value - lower) / step_increment) *
       step_increment) + lower;
+
+  if (priv->clamp_to_center)
+    {
+      gdouble offset = page_size / 2;
+      offset -= step_increment / 2;
+      offset = step_increment - (int) offset % (int) step_increment;
+
+      if (offset > step_increment / 2)
+        offset = - (step_increment - offset);
+
+      d += offset;
+    }
 
   if (mx_adjustment_get_clamp_value (adj))
     d = CLAMP (d, lower, upper - page_size);

--- a/mx/mx-label.c
+++ b/mx/mx-label.c
@@ -372,7 +372,8 @@ mx_label_unmap (ClutterActor *actor)
 {
   MxLabelPrivate *priv = MX_LABEL (actor)->priv;
 
-  clutter_actor_unmap (priv->label);
+  if (priv->label)
+    clutter_actor_unmap (priv->label);
 
   CLUTTER_ACTOR_CLASS (mx_label_parent_class)->unmap (actor);
 }

--- a/mx/mx-offscreen.c
+++ b/mx/mx-offscreen.c
@@ -60,6 +60,8 @@ struct _MxOffscreenPrivate
 
   guint         in_dispose  : 1;
 
+  guint         pre_paint_done : 1;
+
   ClutterActor *child;
 
   CoglHandle    fbo;
@@ -780,8 +782,15 @@ mx_offscreen_pre_paint_cb (ClutterActor *actor,
                            MxOffscreen  *offscreen)
 {
   CoglColor zero_colour;
-
+  gfloat width, height;
   MxOffscreenPrivate *priv = offscreen->priv;
+
+  priv->pre_paint_done = FALSE;
+
+  clutter_actor_get_size (actor, &width, &height);
+
+  if (width * height < 1)
+    return FALSE;
 
   if (!mx_offscreen_ensure_buffers (offscreen))
     {
@@ -807,6 +816,8 @@ mx_offscreen_pre_paint_cb (ClutterActor *actor,
                   COGL_BUFFER_BIT_DEPTH);
     }
 
+  priv->pre_paint_done = TRUE;
+
   return TRUE;
 }
 
@@ -816,7 +827,7 @@ mx_offscreen_post_paint_cb (ClutterActor *actor,
 {
   MxOffscreenPrivate *priv = offscreen->priv;
 
-  if (!priv->fbo)
+  if (!priv->fbo || !priv->pre_paint_done)
     return;
 
   /* Restore state */

--- a/mx/mx-progress-bar.c
+++ b/mx/mx-progress-bar.c
@@ -178,8 +178,11 @@ static void
 mx_progress_bar_unmap (ClutterActor *actor)
 {
   MxProgressBarPrivate *priv = MX_PROGRESS_BAR (actor)->priv;
+
+  if (priv->fill)
+    clutter_actor_unmap (priv->fill);
+
   CLUTTER_ACTOR_CLASS (mx_progress_bar_parent_class)->unmap (actor);
-  clutter_actor_unmap (priv->fill);
 }
 
 static void

--- a/mx/mx-scroll-bar.c
+++ b/mx/mx-scroll-bar.c
@@ -250,9 +250,14 @@ mx_scroll_bar_unmap (ClutterActor *actor)
 
   CLUTTER_ACTOR_CLASS (mx_scroll_bar_parent_class)->unmap (actor);
 
-  clutter_actor_unmap (priv->bw_stepper);
-  clutter_actor_unmap (priv->fw_stepper);
-  clutter_actor_unmap (priv->trough);
+  if (priv->bw_stepper)
+    clutter_actor_unmap (priv->bw_stepper);
+
+  if (priv->fw_stepper)
+    clutter_actor_unmap (priv->fw_stepper);
+
+  if (priv->trough)
+    clutter_actor_unmap (priv->trough);
 
   if (priv->handle)
     clutter_actor_unmap (priv->handle);

--- a/mx/mx-scroll-view.c
+++ b/mx/mx-scroll-view.c
@@ -219,7 +219,10 @@ mx_scroll_view_paint (ClutterActor *actor)
   clutter_color_free (color);
 
   /* MxBin will paint the child */
+  clutter_actor_get_allocation_box (priv->child, &box);
+  cogl_clip_push_rectangle (0, 0, (box.x2 - box.x1), (box.y2 - box.y1));
   CLUTTER_ACTOR_CLASS (mx_scroll_view_parent_class)->paint (actor);
+  cogl_clip_pop ();
 
 
   clutter_actor_get_allocation_box (actor, &box);
@@ -884,8 +887,7 @@ mx_scroll_view_init (MxScrollView *self)
 
   /* mouse scroll is enabled by default, so we also need to be reactive */
   priv->mouse_scroll = TRUE;
-  g_object_set (G_OBJECT (self), "reactive", TRUE, "clip-to-allocation", TRUE,
-                NULL);
+  g_object_set (G_OBJECT (self), "reactive", TRUE, NULL);
 
   g_signal_connect (self, "style-changed",
                     G_CALLBACK (mx_scroll_view_style_changed), NULL);

--- a/mx/mx-scroll-view.c
+++ b/mx/mx-scroll-view.c
@@ -218,11 +218,17 @@ mx_scroll_view_paint (ClutterActor *actor)
   b = color->blue;
   clutter_color_free (color);
 
-  /* MxBin will paint the child */
-  clutter_actor_get_allocation_box (priv->child, &box);
-  cogl_clip_push_rectangle (0, 0, (box.x2 - box.x1), (box.y2 - box.y1));
+  /* If there is a child to paint, clip it */
+  if (priv->child)
+    {
+      clutter_actor_get_allocation_box (priv->child, &box);
+      cogl_clip_push_rectangle (0, 0, (box.x2 - box.x1), (box.y2 - box.y1));
+    }
+
   CLUTTER_ACTOR_CLASS (mx_scroll_view_parent_class)->paint (actor);
-  cogl_clip_pop ();
+
+  if (priv->child)
+    cogl_clip_pop ();
 
 
   clutter_actor_get_allocation_box (actor, &box);
@@ -355,9 +361,19 @@ mx_scroll_view_pick (ClutterActor       *actor,
                      const ClutterColor *color)
 {
   MxScrollViewPrivate *priv = MX_SCROLL_VIEW (actor)->priv;
+  ClutterActorBox      box;
 
   /* Chain up so we get a bounding box pained (if we are reactive) */
+  if (priv->child)
+    {
+      clutter_actor_get_allocation_box (priv->child, &box);
+      cogl_clip_push_rectangle (0, 0, (box.x2 - box.x1), (box.y2 - box.y1));
+    }
+
   CLUTTER_ACTOR_CLASS (mx_scroll_view_parent_class)->pick (actor, color);
+
+  if (priv->child)
+    cogl_clip_pop ();
 
   /* paint our custom children */
   if (CLUTTER_ACTOR_IS_VISIBLE (priv->hscroll))

--- a/mx/mx-scroll-view.c
+++ b/mx/mx-scroll-view.c
@@ -671,7 +671,8 @@ mx_scroll_view_class_init (MxScrollViewClass *klass)
 
   pspec = g_param_spec_boolean ("enable-gestures",
                                 "Enable Gestures",
-                                "Enable use of pointer gestures for scrolling",
+                                "Enable use of pointer gestures for scrolling "
+                                "if Mx was built with ClutterGesture support",
                                 FALSE,
                                 MX_PARAM_READWRITE);
   g_object_class_install_property (object_class, PROP_ENABLE_GESTURES, pspec);

--- a/mx/mx-slider.c
+++ b/mx/mx-slider.c
@@ -596,12 +596,22 @@ mx_slider_unmap (ClutterActor *actor)
   MxSlider *self = MX_SLIDER (actor);
   MxSliderPrivate *priv = self->priv;
 
+  if (priv->trough_bg)
+    clutter_actor_unmap (priv->trough_bg);
+
+  if (priv->fill)
+    clutter_actor_unmap (priv->fill);
+
+  if (priv->trough)
+    clutter_actor_unmap (priv->trough);
+
+  if (priv->handle)
+    clutter_actor_unmap (priv->handle);
+
+  if (priv->buffer)
+    clutter_actor_unmap (priv->buffer);
+
   CLUTTER_ACTOR_CLASS (mx_slider_parent_class)->unmap (actor);
-  clutter_actor_unmap (priv->trough_bg);
-  clutter_actor_unmap (priv->fill);
-  clutter_actor_unmap (priv->trough);
-  clutter_actor_unmap (priv->handle);
-  clutter_actor_unmap (priv->buffer);
 }
 
 static void
@@ -712,6 +722,12 @@ mx_slider_dispose (GObject *object)
     {
       clutter_actor_unparent (priv->trough);
       priv->trough = NULL;
+    }
+
+  if (priv->buffer)
+    {
+      clutter_actor_destroy (priv->buffer);
+      priv->buffer = NULL;
     }
 
   G_OBJECT_CLASS (mx_slider_parent_class)->dispose (object);

--- a/mx/mx-slider.c
+++ b/mx/mx-slider.c
@@ -205,7 +205,7 @@ on_handle_capture_event (ClutterActor *trough,
         }
     }
 
-  return TRUE;
+  return FALSE;
 }
 
 static void
@@ -313,7 +313,7 @@ on_handle_button_press_event (ClutterActor       *actor,
                             G_CALLBACK (on_handle_capture_event),
                             bar);
 
-  return TRUE;
+  return FALSE;
 }
 
 /*
@@ -571,8 +571,7 @@ mx_slider_allocate (ClutterActor           *actor,
   priv->trough_box_y1 = trough_box.y1;
   priv->trough_box_y2 = trough_box.y2;
 
-  if (!priv->capture_handler)
-    mx_slider_allocate_fill_handle (self, box, flags);
+  mx_slider_allocate_fill_handle (self, box, flags);
 
   clutter_actor_allocate (priv->trough, &trough_box, flags);
 }

--- a/mx/mx-stack.c
+++ b/mx/mx-stack.c
@@ -649,14 +649,11 @@ mx_stack_allocate (ClutterActor           *actor,
 }
 
 static void
-mx_stack_paint (ClutterActor *actor)
+mx_stack_paint_children (ClutterActor *actor)
 {
-  GList *c;
-
   MxStackPrivate *priv = MX_STACK (actor)->priv;
 
-  /* allow MxWidget to paint the background */
-  CLUTTER_ACTOR_CLASS (mx_stack_parent_class)->paint (actor);
+  GList *c;
 
   for (c = priv->children; c; c = c->next)
     {
@@ -687,10 +684,22 @@ mx_stack_paint (ClutterActor *actor)
 }
 
 static void
+mx_stack_paint (ClutterActor *actor)
+{
+  /* allow MxWidget to paint the background */
+  CLUTTER_ACTOR_CLASS (mx_stack_parent_class)->paint (actor);
+
+
+  mx_stack_paint_children (actor);
+}
+
+static void
 mx_stack_pick (ClutterActor       *actor,
                const ClutterColor *color)
 {
-  mx_stack_paint (actor);
+  CLUTTER_ACTOR_CLASS (mx_stack_parent_class)->pick (actor, color);
+
+  mx_stack_paint_children (actor);
 }
 
 static void

--- a/mx/mx-table.c
+++ b/mx/mx-table.c
@@ -575,7 +575,7 @@ mx_table_depth_sort_cb (gconstpointer a,
                         gconstpointer b)
 {
   gfloat depth_a = clutter_actor_get_depth ((ClutterActor *)a);
-  gfloat depth_b = clutter_actor_get_depth ((ClutterActor *)a);
+  gfloat depth_b = clutter_actor_get_depth ((ClutterActor *)b);
 
   if (depth_a < depth_b)
     return -1;

--- a/mx/mx-texture-frame.c
+++ b/mx/mx-texture-frame.c
@@ -34,6 +34,7 @@
 #endif
 
 #include <cogl/cogl.h>
+#include <GL/gl.h>
 
 #include "mx-texture-frame.h"
 #include "mx-private.h"

--- a/mx/mx-toggle.c
+++ b/mx/mx-toggle.c
@@ -257,7 +257,8 @@ mx_toggle_unmap (ClutterActor *actor)
 {
   MxTogglePrivate *priv = MX_TOGGLE (actor)->priv;
 
-  clutter_actor_unmap (priv->handle);
+  if (priv->handle)
+    clutter_actor_unmap (priv->handle);
 
   CLUTTER_ACTOR_CLASS (mx_toggle_parent_class)->unmap (actor);
 }

--- a/mx/mx-toggle.c
+++ b/mx/mx-toggle.c
@@ -575,13 +575,13 @@ mx_toggle_set_active (MxToggle *toggle,
 
       timeline = clutter_alpha_get_timeline (priv->alpha);
 
-      if (clutter_timeline_is_playing (timeline))
-        return;
-
       if (active)
         clutter_timeline_set_direction (timeline, CLUTTER_TIMELINE_FORWARD);
       else
         clutter_timeline_set_direction (timeline, CLUTTER_TIMELINE_BACKWARD);
+
+      if (clutter_timeline_is_playing (timeline))
+        return;
 
       clutter_timeline_rewind (timeline);
 

--- a/mx/mx-toggle.c
+++ b/mx/mx-toggle.c
@@ -511,6 +511,8 @@ mx_toggle_init (MxToggle *self)
   self->priv->handle = g_object_new (MX_TYPE_TOGGLE_HANDLE,
                                      "reactive", TRUE, NULL);
   clutter_actor_set_parent (self->priv->handle, CLUTTER_ACTOR (self));
+  g_object_bind_property (self, "disabled", self->priv->handle, "disabled",
+                          G_BINDING_SYNC_CREATE);
 
   timeline = clutter_timeline_new (300);
   g_signal_connect (timeline, "new-frame",

--- a/mx/mx-toolbar.c
+++ b/mx/mx-toolbar.c
@@ -199,13 +199,13 @@ mx_toolbar_dispose (GObject *object)
 {
   MxToolbarPrivate *priv = MX_TOOLBAR (object)->priv;
 
-  G_OBJECT_CLASS (mx_toolbar_parent_class)->dispose (object);
-
   if (priv->close_button)
     {
       clutter_actor_unparent (priv->close_button);
       priv->close_button = NULL;
     }
+
+  G_OBJECT_CLASS (mx_toolbar_parent_class)->dispose (object);
 }
 
 static void

--- a/mx/mx-tooltip.c
+++ b/mx/mx-tooltip.c
@@ -721,6 +721,9 @@ mx_tooltip_set_text (MxTooltip   *tooltip,
 
   clutter_text_set_text (CLUTTER_TEXT (priv->label), text);
 
+  if (CLUTTER_ACTOR_IS_VISIBLE (tooltip))
+    mx_tooltip_update_position (tooltip);
+
   g_object_notify (G_OBJECT (tooltip), "text");
 }
 

--- a/mx/mx-widget.c
+++ b/mx/mx-widget.c
@@ -1722,6 +1722,11 @@ mx_widget_set_disabled (MxWidget *widget,
     {
       priv->is_disabled = disabled;
 
+      if (disabled)
+        mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "disabled");
+      else
+        mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "disabled");
+
       /* Propagate the disabled state to our children, if necessary */
       if (!priv->parent_disabled && CLUTTER_IS_CONTAINER (widget))
         _mx_widget_propagate_disabled ((ClutterContainer *) widget, disabled);

--- a/mx/mx-widget.c
+++ b/mx/mx-widget.c
@@ -63,7 +63,6 @@ struct _MxWidgetPrivate
   ClutterActor *background_image;
   ClutterColor *bg_color;
 
-  guint         is_hovered : 1;
   guint         is_disabled : 1;
   guint         parent_disabled : 1;
 
@@ -793,13 +792,11 @@ mx_widget_enter (ClutterActor         *actor,
                  ClutterCrossingEvent *event)
 {
   MxWidget *widget = MX_WIDGET (actor);
-  MxWidgetPrivate *priv = widget->priv;
 
   /* This is also expected to handle enter events from child actors
      because they will bubble up */
 
   mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "hover");
-  priv->is_hovered = TRUE;
 
   return FALSE;
 }
@@ -809,7 +806,6 @@ mx_widget_leave (ClutterActor         *actor,
                  ClutterCrossingEvent *event)
 {
   MxWidget *widget = MX_WIDGET (actor);
-  MxWidgetPrivate *priv = widget->priv;
 
   /* If the leave event is simply moving to a child actor then we'll
      ignore it so that the actor will retain its hover state until the
@@ -823,7 +819,6 @@ mx_widget_leave (ClutterActor         *actor,
   mx_widget_long_press_cancel (widget);
   mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "active");
   mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "hover");
-  priv->is_hovered = FALSE;
 
   return FALSE;
 }
@@ -1457,6 +1452,8 @@ mx_widget_set_has_tooltip (MxWidget *widget,
         {
           priv->tooltip = g_object_new (MX_TYPE_TOOLTIP, NULL);
           clutter_actor_set_parent (CLUTTER_ACTOR (priv->tooltip), actor);
+          if (mx_stylable_style_pseudo_class_contains (MX_STYLABLE (widget), "hover"))
+            mx_widget_show_tooltip (widget);
         }
     }
   else

--- a/mx/mx-widget.c
+++ b/mx/mx-widget.c
@@ -811,7 +811,8 @@ mx_widget_leave (ClutterActor         *actor,
      ignore it so that the actor will retain its hover state until the
      pointer moves to an unrelated actor. For this to work the actual
      leave event from the child needs to bubble up to this actor */
-  if (clutter_actor_contains (actor, event->related))
+  if (event->related &&
+      clutter_actor_contains (actor, event->related))
     return FALSE;
 
   mx_widget_hide_tooltip (widget);

--- a/mx/x11/mx-settings-x11.c
+++ b/mx/x11/mx-settings-x11.c
@@ -278,7 +278,7 @@ xsettings_notify_func (const char       *name,
 {
   MxSettingsX11Private *priv = MX_SETTINGS_X11 (cb_data)->priv;
 
-  if (!name)
+  if (!name || !setting)
     return;
 
   if (!strcmp (name, "Net/IconThemeName"))

--- a/tests/test-containers.c
+++ b/tests/test-containers.c
@@ -311,11 +311,21 @@ change_widget (MxComboBox *box,
 
   if (MX_IS_VIEWPORT (actor) || MX_IS_KINETIC_SCROLL_VIEW (actor))
     {
-      ClutterActor *child;
+      ClutterActor *child, *texture;
+      gint x, y;
 
-      child = clutter_texture_new_from_file ("redhand.png", NULL);
-      clutter_texture_set_keep_aspect_ratio (CLUTTER_TEXTURE (child), TRUE);
-      clutter_actor_set_width (child, 1000);
+      child = clutter_group_new ();
+
+      for (x = 0; x < 10; x++)
+        for (y = 0; y < 10; y++)
+          {
+            texture = clutter_texture_new_from_file ("redhand.png", NULL);
+            clutter_texture_set_keep_aspect_ratio (CLUTTER_TEXTURE (texture), TRUE);
+            clutter_container_add_actor (CLUTTER_CONTAINER (child), texture);
+
+            clutter_actor_set_width (texture, 100);
+            clutter_actor_set_position (texture, x * 100, y * 100);
+          }
 
       if (MX_IS_KINETIC_SCROLL_VIEW (actor))
         {

--- a/tests/test-widgets.c
+++ b/tests/test-widgets.c
@@ -197,6 +197,10 @@ change_widget (MxComboBox *box,
   guint n_properties;
   gint i;
 
+  /* test the destroy sequence */
+  if (mx_bin_get_child (MX_BIN (data.frame)))
+    clutter_actor_destroy (mx_bin_get_child (MX_BIN (data.frame)));
+
   typename = mx_combo_box_get_active_text (box);
   id = g_type_from_name (typename);
 


### PR DESCRIPTION
/mx/mx-texture-frame.c & mx/mx-deform-texture.c use definition found in GL/gl.h, but the includes aren't in the src files resulting in the following build errors:
<snip>
../mx/mx-deform-texture.c:496:3: error: unknown type name 'GLushort'
../mx/mx-deform-texture.c:498:3: error: unknown type name 'GLushort'
../mx/mx-deform-texture.c:506:20: error: 'GLushort' undeclared (first use in this function)
<snip>
../mx/mx-texture-frame.c:203:5: error: unknown type name 'GLfloat'
<snip>
