### PR TITLE
Add missing includes for GLushort & GLfloat definitions

### DIFF
--- a/mx/mx-deform-texture.c
+++ b/mx/mx-deform-texture.c
@@ -29,6 +29,8 @@
  * deformation effects with a texture.
  */
 
+#include <GL/gl.h>
+
 #include "mx-deform-texture.h"
 #include "mx-offscreen.h"
 #include "mx-private.h"

--- a/mx/mx-deform-texture.c
+++ b/mx/mx-deform-texture.c
@@ -29,8 +29,6 @@
  * deformation effects with a texture.
  */
 
-#include <GL/gl.h>
-
 #include "mx-deform-texture.h"
 #include "mx-offscreen.h"
 #include "mx-private.h"

--- a/mx/mx-deform-texture.c
+++ b/mx/mx-deform-texture.c
@@ -493,9 +493,9 @@ mx_deform_texture_class_init (MxDeformTextureClass *klass)
 static void
 mx_deform_texture_init_arrays (MxDeformTexture *self)
 {
-  GLushort *idx, *bf_idx;
+  gushort *idx, *bf_idx;
   gint x, y, direction;
-  GLushort *static_indices, *static_bf_indices;
+  gushort *static_indices, *static_bf_indices;
   MxDeformTexturePrivate *priv = self->priv;
 
   mx_deform_texture_free_arrays (self);
@@ -503,8 +503,8 @@ mx_deform_texture_init_arrays (MxDeformTexture *self)
   priv->n_indices = (2 + 2 * priv->tiles_x) *
                     priv->tiles_y +
                     (priv->tiles_y - 1);
-  static_indices = g_new (GLushort, priv->n_indices);
-  static_bf_indices = g_new (GLushort, priv->n_indices);
+  static_indices = g_new (gushort, priv->n_indices);
+  static_bf_indices = g_new (gushort, priv->n_indices);
 
 #define MESH_INDEX(X, Y) (Y) * (priv->tiles_x + 1) + (X)
 

--- a/mx/mx-texture-frame.c
+++ b/mx/mx-texture-frame.c
@@ -34,6 +34,7 @@
 #endif
 
 #include <cogl/cogl.h>
+#include <GL/gl.h>
 
 #include "mx-texture-frame.h"
 #include "mx-private.h"

--- a/mx/mx-texture-frame.c
+++ b/mx/mx-texture-frame.c
@@ -34,7 +34,6 @@
 #endif
 
 #include <cogl/cogl.h>
-#include <GL/gl.h>
 
 #include "mx-texture-frame.h"
 #include "mx-private.h"

--- a/mx/mx-texture-frame.c
+++ b/mx/mx-texture-frame.c
@@ -200,7 +200,7 @@ mx_texture_frame_paint (ClutterActor *self)
 
 
   {
-    GLfloat rectangles[] =
+    gfloat rectangles[] =
     {
       /* top left corner */
       0, 0,


### PR DESCRIPTION
mx/mx-deform-texture.c and mx/mx-texture-frame.c use definitions from GL/gl.h, but the includes aren't in the src files resulting in the following build errors:
<snip>
../mx/mx-deform-texture.c: In function 'mx_deform_texture_init_arrays':
../mx/mx-deform-texture.c:496:3: error: unknown type name 'GLushort'
../mx/mx-deform-texture.c:498:3: error: unknown type name 'GLushort'
../mx/mx-deform-texture.c:506:20: error: 'GLushort' undeclared (first use in this function)
<snip>
<snip>
../mx/mx-texture-frame.c:203:5: error: unknown type name 'GLfloat'
<snip>

The following pull request should fix this.
