### PR TITLE
stylable: introduce optimization for touch based UIs

### DIFF
--- a/mx/mx-button.c
+++ b/mx/mx-button.c
@@ -170,7 +170,8 @@ mx_stylable_iface_init (MxStylableIface *iface)
 static MxFocusable*
 mx_button_accept_focus (MxFocusable *focusable, MxFocusHint hint)
 {
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable), "focus");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable),
+                                      _MX_STYLE_GET_STYLE_CLASS (focus));
 
   clutter_actor_grab_key_focus (CLUTTER_ACTOR (focusable));
 
@@ -184,7 +185,8 @@ mx_button_move_focus (MxFocusable      *focusable,
 {
   /* check if focus is being moved from us */
   if (focusable == from)
-    mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable), "focus");
+    mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable),
+                                           _MX_STYLE_GET_STYLE_CLASS (focus));
 
   return NULL;
 }
@@ -304,7 +306,8 @@ mx_button_push (MxButton     *button,
 
   //clutter_grab_pointer (CLUTTER_ACTOR (button));
 
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (button), "active");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (button),
+                                      _MX_STYLE_GET_STYLE_CLASS(active));
 
   if (event)
     mx_widget_long_press_query (widget, event);
@@ -339,7 +342,8 @@ mx_button_pull (MxButton *button)
 
   mx_widget_long_press_cancel (widget);
 
-  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (button), "active");
+  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (button),
+                                         _MX_STYLE_GET_STYLE_CLASS(active));
 }
 
 static gboolean
@@ -415,7 +419,8 @@ mx_button_touch_event (ClutterActor      *actor,
           if (!_mx_widget_has_touch_sequences (widget) && priv->is_pressed)
             {
               mx_widget_long_press_cancel (widget);
-              mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "active");
+              mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                                     _MX_STYLE_GET_STYLE_CLASS(active));
               priv->is_pressed = FALSE;
             }
         }
@@ -476,7 +481,8 @@ mx_button_enter (ClutterActor         *actor,
     return FALSE;
 
 
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "hover");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget),
+                                      _MX_STYLE_GET_STYLE_CLASS(hover));
 
   return FALSE;
 }
@@ -504,11 +510,13 @@ mx_button_leave (ClutterActor         *actor,
       //clutter_ungrab_pointer ();
 
       mx_widget_long_press_cancel (widget);
-      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "active");
+      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                             _MX_STYLE_GET_STYLE_CLASS(active));
       button->priv->is_pressed = FALSE;
     }
 
-  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "hover");
+  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                         _MX_STYLE_GET_STYLE_CLASS(hover));
 
   return FALSE;
 }

--- a/mx/mx-combo-box.c
+++ b/mx/mx-combo-box.c
@@ -466,7 +466,8 @@ mx_combo_box_action_activated_cb (ClutterActor *menu,
   mx_combo_box_set_index (box, index);
 
   /* reset the combobox style */
-  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (box), "hover");
+  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (box),
+                                         _MX_STYLE_GET_STYLE_CLASS (hover));
 }
 
 static void
@@ -675,7 +676,8 @@ mx_combo_box_init (MxComboBox *self)
 static MxFocusable *
 mx_combo_box_accept_focus (MxFocusable *focusable, MxFocusHint hint)
 {
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable), "focus");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable),
+                                      _MX_STYLE_GET_STYLE_CLASS (focus));
 
   clutter_actor_grab_key_focus (CLUTTER_ACTOR (focusable));
 
@@ -689,7 +691,8 @@ mx_combo_box_move_focus (MxFocusable      *focusable,
 {
   if (focusable == from)
     {
-      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable), "focus");
+      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable),
+                                             _MX_STYLE_GET_STYLE_CLASS (focus));
     }
 
   return NULL;

--- a/mx/mx-entry.c
+++ b/mx/mx-entry.c
@@ -617,7 +617,8 @@ static void
 clutter_text_focus_in_cb (ClutterText  *text,
                           ClutterActor *actor)
 {
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (actor), "focus");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (actor),
+                                      _MX_STYLE_GET_STYLE_CLASS (focus));
   clutter_text_set_cursor_visible (text, TRUE);
 }
 

--- a/mx/mx-private.h
+++ b/mx/mx-private.h
@@ -66,7 +66,8 @@ typedef enum
   MX_SETTINGS_FONT_NAME,
   MX_SETTINGS_LONG_PRESS_TIMEOUT,
   MX_SETTINGS_SMALL_SCREEN,
-  MX_SETTINGS_DRAG_THRESHOLD
+  MX_SETTINGS_DRAG_THRESHOLD,
+  MX_SETTINGS_TOUCH_MODE
 } MxSettingsProperty;
 
 
@@ -109,6 +110,9 @@ void _mx_paint_texture_with_opacity (CoglHandle texture,
                                      gfloat     width,
                                      gfloat     height);
 
+gboolean _mx_settings_get_touch_mode (MxSettings *settings);
+
+
 typedef enum
 {
   MX_DEBUG_LAYOUT      = 1 << 0,
@@ -119,6 +123,17 @@ typedef enum
 } MxDebugTopic;
 
 gboolean _mx_debug (gint debug);
+
+#define _MX_STYLE_DEFINE_STYLE_CLASS_DEF(name) \
+  const gchar* _mx_style_common_style_class_##name(void)
+
+#define _MX_STYLE_GET_STYLE_CLASS(name) \
+  _mx_style_common_style_class_##name()
+
+_MX_STYLE_DEFINE_STYLE_CLASS_DEF (active);
+_MX_STYLE_DEFINE_STYLE_CLASS_DEF (disabled);
+_MX_STYLE_DEFINE_STYLE_CLASS_DEF (focus);
+_MX_STYLE_DEFINE_STYLE_CLASS_DEF (hover);
 
 #ifdef G_HAVE_ISO_VARARGS
 

--- a/mx/mx-slider.c
+++ b/mx/mx-slider.c
@@ -34,6 +34,7 @@
 #include "mx-button.h"
 #include "mx-frame.h"
 #include "mx-focusable.h"
+#include "mx-private.h"
 
 static void mx_stylable_iface_init (MxStylableIface *iface);
 static void mx_focusable_iface_init (MxFocusableIface *iface);
@@ -109,7 +110,8 @@ mx_slider_move_focus (MxFocusable      *focusable,
                       MxFocusDirection  direction,
                       MxFocusable      *old_focus)
 {
-  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable), "focus");
+  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable),
+                                         _MX_STYLE_GET_STYLE_CLASS (focus));
 
   return NULL;
 }
@@ -120,7 +122,8 @@ mx_slider_accept_focus (MxFocusable *focusable,
 {
   clutter_actor_grab_key_focus (CLUTTER_ACTOR (focusable));
 
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable), "focus");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable),
+                                      _MX_STYLE_GET_STYLE_CLASS (focus));
 
   return focusable;
 }

--- a/mx/mx-stylable.c
+++ b/mx/mx-stylable.c
@@ -61,6 +61,17 @@ enum
   LAST_SIGNAL
 };
 
+#define _MX_STYLE_DEFINE_STYLE_CLASS_FUNC(name) \
+  const gchar* _mx_style_common_style_class_##name(void) \
+  {                                                     \
+    return #name;                                       \
+  }
+
+_MX_STYLE_DEFINE_STYLE_CLASS_FUNC (active);
+_MX_STYLE_DEFINE_STYLE_CLASS_FUNC (disabled);
+_MX_STYLE_DEFINE_STYLE_CLASS_FUNC (focus);
+_MX_STYLE_DEFINE_STYLE_CLASS_FUNC (hover);
+
 static GObjectNotifyContext property_notify_context = { 0, };
 
 static GParamSpecPool *style_property_spec_pool = NULL;
@@ -908,6 +919,11 @@ mx_stylable_style_pseudo_class_add (MxStylable  *stylable,
 
   g_return_if_fail (MX_IS_STYLABLE (stylable));
   g_return_if_fail (new_class != NULL);
+
+  /**/
+  if (new_class == _MX_STYLE_GET_STYLE_CLASS(hover) &&
+      _mx_settings_get_touch_mode (mx_settings_get_default()))
+    return;
 
   /* check if the pseudo class already contains new_class */
   if (mx_stylable_style_pseudo_class_contains (stylable, new_class))

--- a/mx/mx-toggle.c
+++ b/mx/mx-toggle.c
@@ -174,8 +174,10 @@ mx_toggle_accept_focus (MxFocusable *focusable, MxFocusHint hint)
 {
   MxTogglePrivate *priv = MX_TOGGLE (focusable)->priv;
 
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable), "focus");
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (priv->handle), "focus");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (focusable),
+                                      _MX_STYLE_GET_STYLE_CLASS (focus));
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (priv->handle),
+                                      _MX_STYLE_GET_STYLE_CLASS (focus));
 
   clutter_actor_grab_key_focus (CLUTTER_ACTOR (focusable));
 
@@ -192,8 +194,10 @@ mx_toggle_move_focus (MxFocusable      *focusable,
     {
       MxTogglePrivate *priv = MX_TOGGLE (focusable)->priv;
 
-      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable), "focus");
-      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (priv->handle), "focus");
+      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (focusable),
+                                             _MX_STYLE_GET_STYLE_CLASS (focus));
+      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (priv->handle),
+                                             _MX_STYLE_GET_STYLE_CLASS (focus));
     }
 
   return NULL;
@@ -387,7 +391,8 @@ mx_toggle_handle_button_release_event (ClutterActor       *actor,
    * during the grab */
   clutter_actor_get_allocation_box (actor, &box);
   if (!clutter_actor_box_contains (&box, event->x, event->y))
-    mx_stylable_style_pseudo_class_remove (MX_STYLABLE (actor), "hover");
+    mx_stylable_style_pseudo_class_remove (MX_STYLABLE (actor),
+                                           _MX_STYLE_GET_STYLE_CLASS (hover));
 
   return TRUE;
 }

--- a/mx/mx-widget.c
+++ b/mx/mx-widget.c
@@ -859,7 +859,8 @@ mx_widget_enter (ClutterActor         *actor,
   /* This is also expected to handle enter events from child actors
      because they will bubble up */
 
-  mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "hover");
+  mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget),
+                                      _MX_STYLE_GET_STYLE_CLASS (hover));
 
   return FALSE;
 }
@@ -880,8 +881,10 @@ mx_widget_leave (ClutterActor         *actor,
   mx_widget_hide_tooltip (widget);
 
   mx_widget_long_press_cancel (widget);
-  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "active");
-  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "hover");
+  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                         _MX_STYLE_GET_STYLE_CLASS (active));
+  mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                         _MX_STYLE_GET_STYLE_CLASS (hover));
 
   return FALSE;
 }
@@ -1010,7 +1013,8 @@ mx_widget_button_press (ClutterActor       *actor,
       return TRUE;
 
   if (event->button == 1)
-    mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "active");
+    mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget),
+                                        _MX_STYLE_GET_STYLE_CLASS (active));
 
   mx_widget_long_press_query (widget, (ClutterEvent *) event);
 
@@ -1027,7 +1031,8 @@ mx_widget_button_release (ClutterActor       *actor,
       return TRUE;
 
   if (event->button == 1)
-    mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "active");
+    mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                           _MX_STYLE_GET_STYLE_CLASS (active));
 
   mx_widget_long_press_cancel (widget);
 
@@ -1046,7 +1051,8 @@ mx_widget_touch_event (ClutterActor      *actor,
   switch (event->type)
     {
     case CLUTTER_TOUCH_BEGIN:
-      mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "active");
+      mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget),
+                                          _MX_STYLE_GET_STYLE_CLASS (active));
       _mx_widget_add_touch_sequence (widget, event->sequence);
       mx_widget_long_press_query (widget, (ClutterEvent *) event);
       break;
@@ -1057,7 +1063,8 @@ mx_widget_touch_event (ClutterActor      *actor,
         return FALSE;
 
       _mx_widget_remove_touch_sequence (widget, event->sequence);
-      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "active");
+      mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                             _MX_STYLE_GET_STYLE_CLASS (active));
       mx_widget_long_press_cancel (widget);
       break;
 
@@ -1103,10 +1110,10 @@ _mx_widget_propagate_disabled (ClutterActor *container,
 
           if (disabled)
             mx_stylable_style_pseudo_class_add (MX_STYLABLE (child),
-                                                "disabled");
+                                                _MX_STYLE_GET_STYLE_CLASS (disabled));
           else
             mx_stylable_style_pseudo_class_remove (MX_STYLABLE (child),
-                                                   "disabled");
+                                                   _MX_STYLE_GET_STYLE_CLASS (disabled));
 
           /* If this child has already been disabled explicitly,
            * we don't need to recurse through its children to set
@@ -1602,7 +1609,8 @@ mx_widget_set_has_tooltip (MxWidget *widget,
         {
           priv->tooltip = g_object_new (MX_TYPE_TOOLTIP, NULL);
           clutter_actor_add_child (actor, CLUTTER_ACTOR (priv->tooltip));
-          if (mx_stylable_style_pseudo_class_contains (MX_STYLABLE (widget), "hover"))
+          if (mx_stylable_style_pseudo_class_contains (MX_STYLABLE (widget),
+                                                       _MX_STYLE_GET_STYLE_CLASS (hover)))
             mx_widget_show_tooltip (widget);
         }
     }
@@ -1846,9 +1854,11 @@ mx_widget_set_disabled (MxWidget *widget,
       priv->is_disabled = disabled;
 
       if (disabled)
-        mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget), "disabled");
+        mx_stylable_style_pseudo_class_add (MX_STYLABLE (widget),
+                                            _MX_STYLE_GET_STYLE_CLASS (disabled));
       else
-        mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget), "disabled");
+        mx_stylable_style_pseudo_class_remove (MX_STYLABLE (widget),
+                                               _MX_STYLE_GET_STYLE_CLASS (disabled));
 
       /* Propagate the disabled state to our children, if necessary */
       if (!priv->parent_disabled)


### PR DESCRIPTION
This is an optimization for touch based UI.
It basically drop all hover states and therefore avoid applying new CSS styles when your finger moves over widgets.
