### PR TITLE
kinetic-scroll-view: use mx_adjustment_interpolate instead  of mx_adjustment_set_value

### DIFF
--- a/mx/mx-kinetic-scroll-view.c
+++ b/mx/mx-kinetic-scroll-view.c
@@ -957,8 +957,13 @@ motion_event_cb (ClutterActor        *actor,
                (priv->in_automatic_scroll == MX_AUTOMATIC_SCROLL_HORIZONTAL ||
                priv->in_automatic_scroll == MX_AUTOMATIC_SCROLL_NONE))
             {
-              dx = (motion->x - x) + mx_adjustment_get_value (hadjust);
-              mx_adjustment_interpolate (hadjust, dx, KINETIC_INTERPOLATION_TIMEOUT, CLUTTER_EASE_OUT_CUBIC);
+              gdouble current = mx_adjustment_get_value (hadjust);
+              dx = (motion->x - x) + current;
+              if (dx > current ? dx - current : current - dx >
+                  (((mx_adjustment_get_upper (hadjust) - mx_adjustment_get_lower (hadjust)) / 100) * 30))
+                mx_adjustment_interpolate (hadjust, dx, KINETIC_INTERPOLATION_TIMEOUT, CLUTTER_LINEAR);
+              else
+                mx_adjustment_set_value (hadjust, dx);
             }
 
           if (vadjust &&
@@ -968,8 +973,13 @@ motion_event_cb (ClutterActor        *actor,
                (priv->in_automatic_scroll == MX_AUTOMATIC_SCROLL_VERTICAL ||
                priv->in_automatic_scroll == MX_AUTOMATIC_SCROLL_NONE))
             {
-              dy = (motion->y - y) + mx_adjustment_get_value (vadjust);
-              mx_adjustment_interpolate (vadjust, dy, KINETIC_INTERPOLATION_TIMEOUT, CLUTTER_EASE_OUT_CUBIC);
+              gdouble current = mx_adjustment_get_value (vadjust);
+              dy = (motion->y - y) + current;
+              if (dy > current ? dy - current : current - dy >
+                  (((mx_adjustment_get_upper (vadjust) - mx_adjustment_get_lower (vadjust)) / 100) * 30))
+                mx_adjustment_interpolate (vadjust, dy, KINETIC_INTERPOLATION_TIMEOUT, CLUTTER_LINEAR);
+              else
+                mx_adjustment_set_value (vadjust, dy);
             }
         }
 

--- a/mx/mx-kinetic-scroll-view.c
+++ b/mx/mx-kinetic-scroll-view.c
@@ -61,6 +61,8 @@ G_DEFINE_TYPE_WITH_CODE (MxKineticScrollView,
                                         MX_TYPE_KINETIC_SCROLL_VIEW, \
                                         MxKineticScrollViewPrivate))
 
+#define KINETIC_INTERPOLATION_TIMEOUT 10
+
 typedef struct {
   /* Units to store the origin of a click when scrolling */
   gfloat   x;
@@ -956,7 +958,7 @@ motion_event_cb (ClutterActor        *actor,
                priv->in_automatic_scroll == MX_AUTOMATIC_SCROLL_NONE))
             {
               dx = (motion->x - x) + mx_adjustment_get_value (hadjust);
-              mx_adjustment_set_value (hadjust, dx);
+              mx_adjustment_interpolate (hadjust, dx, KINETIC_INTERPOLATION_TIMEOUT, CLUTTER_EASE_OUT_CUBIC);
             }
 
           if (vadjust &&
@@ -967,7 +969,7 @@ motion_event_cb (ClutterActor        *actor,
                priv->in_automatic_scroll == MX_AUTOMATIC_SCROLL_NONE))
             {
               dy = (motion->y - y) + mx_adjustment_get_value (vadjust);
-              mx_adjustment_set_value (vadjust, dy);
+              mx_adjustment_interpolate (vadjust, dy, KINETIC_INTERPOLATION_TIMEOUT, CLUTTER_EASE_OUT_CUBIC);
             }
         }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,8 @@ noinst_PROGRAMS = 			\
 	test-droppable			\
 	test-window 			\
 	test-widgets			\
-	test-containers
+	test-containers			\
+	test-kinetic-scroll-view	\
 	$(NULL)
 
 test_widgets_SOURCES = test-widgets.c
@@ -22,6 +23,8 @@ test_draggable_SOURCES = test-draggable.c
 test_droppable_SOURCES = test-droppable.c
 
 test_window_SOURCES = test-window.c
+
+test_kinetic_scroll_view_SOURCES = test-kinetic-scroll-view.c
 
 EXTRA_DIST = redhand.png
 

--- a/tests/test-kinetic-scroll-view.c
+++ b/tests/test-kinetic-scroll-view.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013 Collabora Ltd.
+ *
+ * Authors: Rodrigo Moya <rodrigo.moya@collabora.co.uk>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU Lesser General Public License,
+ * version 2.1, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include <mx/mx.h>
+
+static void
+startup_cb (MxApplication *application)
+{
+  MxWindow *window;
+  ClutterActor *scroll, *child;
+  gint i;
+
+  window = mx_application_create_window (application, "Test Widgets");
+
+  /* Create scroll view */
+  scroll = mx_kinetic_scroll_view_new ();
+  mx_kinetic_scroll_view_set_use_grab (MX_KINETIC_SCROLL_VIEW (scroll), TRUE);
+  mx_kinetic_scroll_view_set_mouse_button (MX_KINETIC_SCROLL_VIEW (scroll), 3);
+  clutter_actor_set_clip_to_allocation (scroll, TRUE);
+
+  child = mx_box_layout_new_with_orientation (MX_ORIENTATION_VERTICAL);
+
+  for (i = 0; i < 10000; i++) {
+    ClutterActor *layout, *label, *icon;
+    gchar *s = g_strdup_printf ("Row %d", i);
+
+    layout = mx_box_layout_new_with_orientation (MX_ORIENTATION_HORIZONTAL);
+    label = mx_label_new_with_text (s);
+    clutter_actor_add_child (layout, label);
+    g_free (s);
+
+    icon = mx_icon_new ();
+    mx_icon_set_icon_name (MX_ICON (icon), "object-rotate-left");
+    mx_icon_set_icon_size (MX_ICON (icon), 32);
+    clutter_actor_add_child (layout, icon);
+
+    clutter_actor_add_child (child, layout);
+  }
+
+  clutter_actor_add_child (scroll, child);
+
+  mx_window_set_child (window, scroll);
+
+  /* show the window */
+  mx_window_set_has_toolbar (window, FALSE);
+  mx_window_show (window);
+}
+
+int
+main (int argc, char *argv[])
+{
+  MxApplication *application;
+
+  application = mx_application_new ("org.clutter-project.Mx.TestKineticScrollView", 0);
+  g_signal_connect_after (application, "startup", G_CALLBACK (startup_cb), NULL);
+
+  /* run the application */
+  g_application_run (G_APPLICATION (application), argc, argv);
+
+  return 0;
+}


### PR DESCRIPTION
...ent_set_value

This prevents "jumps" when getting events from low resolution input devices,
so that the panning movement is continous.
