### PR TITLE
Use clamp value as reference for interpolating

### DIFF
--- a/mx/mx-kinetic-scroll-view.c
+++ b/mx/mx-kinetic-scroll-view.c
@@ -1040,7 +1040,7 @@ clamp_adjustment (MxKineticScrollView *scroll,
       d += offset;
     }
 
-  if (value != 0)
+  if (mx_adjustment_get_clamp_value (adj))
     {
       d = CLAMP (d, lower, upper - page_size);
       if (fabs ((upper - page_size) - value) < fabs (d - value))


### PR DESCRIPTION
This was used in 1.4.6, and the change in 2.0 seems to cause strange behavior,
specially when scrolling in a direction such that the vertical adjustment
decreases.
