### PR TITLE
Fix -Wstrict-prototypes warnings

### DIFF
--- a/mx/mx-stack.h
+++ b/mx/mx-stack.h
@@ -87,7 +87,7 @@ struct _MxStackClass
 
 GType mx_stack_get_type (void) G_GNUC_CONST;
 
-ClutterActor *mx_stack_new ();
+ClutterActor *mx_stack_new (void);
 
 G_END_DECLS
 

--- a/mx/mx-utils.h
+++ b/mx/mx-utils.h
@@ -36,7 +36,7 @@
 
 G_BEGIN_DECLS
 
-void   mx_set_locale ();
+void   mx_set_locale (void);
 
 gchar *mx_utils_format_time (GTimeVal *time_);
 


### PR DESCRIPTION
Recent GCC generates "warning: function declaration isn't a prototype" when
building with -Wstrict-prototypes.
