### PR TITLE
_mx_entry_icon_leave_cb: target_tooltip may be NULL

### DIFF
--- a/mx/mx-entry.c
+++ b/mx/mx-entry.c
@@ -1692,7 +1692,8 @@ _mx_entry_icon_leave_cb (ClutterActor *actor,
       priv->tooltip_timeout = 0;
     }
 
-  mx_tooltip_hide (target_tooltip);
+  if (target_tooltip)
+    mx_tooltip_hide (target_tooltip);
 
   return FALSE;
 }


### PR DESCRIPTION
Fix a run time warning.

Backport from 1.4
