### PR TITLE
kinetic-scroll-view: document correct :snap-on-page default value

### DIFF
--- a/mx/mx-kinetic-scroll-view.c
+++ b/mx/mx-kinetic-scroll-view.c
@@ -727,7 +727,7 @@ mx_kinetic_scroll_view_class_init (MxKineticScrollViewClass *klass)
   pspec = g_param_spec_boolean ("snap-on-page",
                                 "Snap on page",
                                 "Whether to stop animations on step increments.",
-                                FALSE,
+                                TRUE,
                                 MX_PARAM_READWRITE);
   g_object_class_install_property (object_class, PROP_SNAP_ON_PAGE, pspec);
 


### PR DESCRIPTION
The g_param_spec_boolean() definition for :snap-on-page had a default
value of FALSE but actually in _init it's set to TRUE.
