### PR TITLE
mx-style: Do not call g_file_test(NULL)

### DIFF
--- a/mx/mx-style.c
+++ b/mx/mx-style.c
@@ -308,7 +308,7 @@ mx_style_load (MxStyle *style)
 
   error = NULL;
 
-  if (g_file_test (rc_file, G_FILE_TEST_EXISTS))
+  if (rc_file != NULL && g_file_test (rc_file, G_FILE_TEST_EXISTS))
     {
       /* load the default theme with lowest priority */
       if (!mx_style_real_load_from_file (style, rc_file, NULL, &error, 0))


### PR DESCRIPTION
This can result in a call to access(NULL, …), which is not allowed
(although appears to be harmless on my Fedora 22 machine). Valgrind
complains about it.

See: https://bugzilla.gnome.org/show_bug.cgi?id=755046
