### PR TITLE
kinetic-scroll-view: Various fixes for the motion buffer

### DIFF
--- a/mx/mx-kinetic-scroll-view.c
+++ b/mx/mx-kinetic-scroll-view.c
@@ -163,11 +163,11 @@ _log_debug (MxKineticScrollView *scroll, const gchar *fmt, ...)
 
   va_start (args, fmt);
 
-  new_fmt = g_strdup_printf ("%s(%p): %s",
+  new_fmt = g_strdup_printf ("%s(%p): %" G_GINT64_FORMAT ": %s",
                              (scroll->priv->scroll_policy == MX_SCROLL_POLICY_VERTICAL) ?
                              "vert" :
                              ((scroll->priv->scroll_policy == MX_SCROLL_POLICY_HORIZONTAL) ? "hori" : "both"),
-                             scroll, fmt);
+                             scroll, g_get_monotonic_time (), fmt);
 
   g_logv ("Mx", G_LOG_LEVEL_MESSAGE, new_fmt, args);
 


### PR DESCRIPTION
Various fixes made in the course of investigating a problem where kinetic scrolling would not work due to the frame in which the touchscreen was released taking 400ms to complete — this was because the scroll view had many rows, and the `MxStylable::style-changed` signal propagation to all of them was taking forever.

Anyway, these fixes should improve the behaviour of the motion buffer. Instead of dropping the earliest buffer entries when the buffer fills up, it eliminates the buffer entirely and calculates a moving average of the motion events. There are also some debug message improvements.
